### PR TITLE
re-add the removed IForgeRegistryEntry#getRegistryName

### DIFF
--- a/src/main/java/net/silentchaos512/lib/registry/BlockRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/BlockRegistryObject.java
@@ -4,6 +4,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraftforge.registries.RegistryObject;
 import net.silentchaos512.lib.block.IBlockProvider;
 
+@Deprecated(forRemoval = true)
 public class BlockRegistryObject<T extends Block> extends RegistryObjectWrapper<T> implements IBlockProvider {
     public BlockRegistryObject(RegistryObject<T> block) {
         super(block);

--- a/src/main/java/net/silentchaos512/lib/registry/ItemRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/ItemRegistryObject.java
@@ -3,7 +3,7 @@ package net.silentchaos512.lib.registry;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
 import net.minecraftforge.registries.RegistryObject;
-
+@Deprecated(forRemoval = true)
 public class ItemRegistryObject<T extends Item> extends RegistryObjectWrapper<T> implements ItemLike {
     public ItemRegistryObject(RegistryObject<T> item) {
         super(item);

--- a/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/BlockDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/BlockDeferredRegister.java
@@ -1,0 +1,18 @@
+package net.silentchaos512.lib.registry.updated.deferredregisters;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.silentchaos512.lib.registry.updated.registryobjects.BlockRegistryObject;
+
+import java.util.function.Supplier;
+
+public class BlockDeferredRegister extends DeferredRegisterWrapper<Block> {
+    public BlockDeferredRegister(String modid) {
+        super(modid, ForgeRegistries.BLOCKS);
+    }
+
+    @Override
+    public <U extends Block> BlockRegistryObject<U> register(String name, Supplier<U> supplier) {
+        return new BlockRegistryObject<>(this, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/BlockEntityDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/BlockEntityDeferredRegister.java
@@ -1,0 +1,26 @@
+package net.silentchaos512.lib.registry.updated.deferredregisters;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.silentchaos512.lib.registry.updated.registryobjects.BlockEntityTypeRegistryObject;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class BlockEntityDeferredRegister extends DeferredRegisterWrapper<BlockEntityType<?>> {
+    public BlockEntityDeferredRegister(String modid) {
+        super(modid, ForgeRegistries.BLOCK_ENTITY_TYPES);
+    }
+
+    @Override
+    @Deprecated
+    public <U extends BlockEntityType<?>> BlockEntityTypeRegistryObject<? extends BlockEntity> register(String name, Supplier<U> supplier) {
+        throw new IllegalStateException("Please use another implementation for registration");
+    }
+
+    public <BE extends BlockEntity> BlockEntityTypeRegistryObject<BE> register(String name, BlockEntityType.BlockEntitySupplier<BE> beSupplier, List<Supplier<Block>> validBlocksSupplier) {
+        return new BlockEntityTypeRegistryObject<BE>(this, name, beSupplier, validBlocksSupplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/DeferredRegisterWrapper.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/DeferredRegisterWrapper.java
@@ -1,0 +1,24 @@
+package net.silentchaos512.lib.registry.updated.deferredregisters;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.silentchaos512.lib.registry.updated.registryobjects.UpdatedRegistryObjectWrapper;
+
+import java.util.function.Supplier;
+
+public abstract class DeferredRegisterWrapper<T> {
+    public final DeferredRegister<T> instance;
+    public final String modid;
+
+    public DeferredRegisterWrapper(String modid, IForgeRegistry<T> registry) {
+        this.modid = modid;
+        this.instance = DeferredRegister.create(registry, modid);
+    }
+
+    public void registerBus(IEventBus eventBus) {
+        this.instance.register(eventBus);
+    }
+
+    public abstract <U extends T> UpdatedRegistryObjectWrapper<?> register(String name, Supplier<U> supplier);
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/FluidDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/FluidDeferredRegister.java
@@ -1,0 +1,18 @@
+package net.silentchaos512.lib.registry.updated.deferredregisters;
+
+import net.minecraft.world.level.material.Fluid;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.silentchaos512.lib.registry.updated.registryobjects.FluidRegistryObject;
+
+import java.util.function.Supplier;
+
+public class FluidDeferredRegister extends DeferredRegisterWrapper<Fluid> {
+    public FluidDeferredRegister(String modid) {
+        super(modid, ForgeRegistries.FLUIDS);
+    }
+
+    @Override
+    public <U extends Fluid> FluidRegistryObject<U> register(String name, Supplier<U> supplier) {
+        return new FluidRegistryObject<>(this, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/FluidTypeDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/FluidTypeDeferredRegister.java
@@ -1,0 +1,18 @@
+package net.silentchaos512.lib.registry.updated.deferredregisters;
+
+import net.minecraftforge.fluids.FluidType;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.silentchaos512.lib.registry.updated.registryobjects.FluidTypeRegistryObject;
+
+import java.util.function.Supplier;
+
+public class FluidTypeDeferredRegister extends DeferredRegisterWrapper<FluidType> {
+    public FluidTypeDeferredRegister(String modid) {
+        super(modid, ForgeRegistries.FLUID_TYPES.get());
+    }
+
+    @Override
+    public <U extends FluidType> FluidTypeRegistryObject<U> register(String name, Supplier<U> supplier) {
+        return new FluidTypeRegistryObject<>(this, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/ItemDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/ItemDeferredRegister.java
@@ -1,0 +1,18 @@
+package net.silentchaos512.lib.registry.updated.deferredregisters;
+
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.silentchaos512.lib.registry.updated.registryobjects.ItemRegistryObject;
+
+import java.util.function.Supplier;
+
+public class ItemDeferredRegister extends DeferredRegisterWrapper<Item> {
+    public ItemDeferredRegister(String modid) {
+        super(modid, ForgeRegistries.ITEMS);
+    }
+
+    @Override
+    public <U extends Item> ItemRegistryObject<U> register(String name, Supplier<U> supplier) {
+        return new ItemRegistryObject<>(this, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/RecipeTypeDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/deferredregisters/RecipeTypeDeferredRegister.java
@@ -1,0 +1,42 @@
+package net.silentchaos512.lib.registry.updated.deferredregisters;
+
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.silentchaos512.lib.SilentLib;
+import net.silentchaos512.lib.registry.updated.registryobjects.RecipeSerializerRegistryObject;
+import net.silentchaos512.lib.registry.updated.registryobjects.RecipeTypeRegistryObject;
+import net.silentchaos512.lib.registry.updated.registryobjects.UpdatedRegistryObjectWrapper;
+
+import java.util.function.Supplier;
+
+public class RecipeTypeDeferredRegister extends DeferredRegisterWrapper<RecipeType<?>> {
+    private final DeferredRegister<RecipeSerializer<?>> serializerDeferredRegister = DeferredRegister.create(ForgeRegistries.RECIPE_SERIALIZERS, super.modid);
+
+    public RecipeTypeDeferredRegister(String modid) {
+        super(modid, ForgeRegistries.RECIPE_TYPES);
+    }
+
+    @Deprecated
+    @Override
+    public <U extends RecipeType<?>> UpdatedRegistryObjectWrapper<?> register(String name, Supplier<U> supplier) {
+        throw new IllegalStateException("Please use another implementation for registration");
+    }
+
+    public <T extends Recipe<?>> RecipeTypeRegistryObject<T> register(String name) {
+        return new RecipeTypeRegistryObject<>(this, name, () -> RecipeType.simple(SilentLib.getId(name)));
+    }
+
+    public <T extends Recipe<?>>RecipeSerializerRegistryObject<T> registerSerializer(String name, Supplier<RecipeSerializer<T>> serializerSupplier) {
+        return new RecipeSerializerRegistryObject<>(this.serializerDeferredRegister, super.modid, name, serializerSupplier);
+    }
+
+    @Override
+    public void registerBus(IEventBus eventBus) {
+        super.registerBus(eventBus);
+        this.serializerDeferredRegister.register(eventBus);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/BlockEntityTypeRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/BlockEntityTypeRegistryObject.java
@@ -1,0 +1,20 @@
+package net.silentchaos512.lib.registry.updated.registryobjects;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.silentchaos512.lib.registry.updated.deferredregisters.DeferredRegisterWrapper;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class BlockEntityTypeRegistryObject<T extends BlockEntity> extends UpdatedRegistryObjectWrapper<BlockEntityType<?>> {
+    public BlockEntityTypeRegistryObject(DeferredRegisterWrapper<BlockEntityType<?>> deferredRegister, String name, BlockEntityType.BlockEntitySupplier<T> blockEntitySupplier, List<Supplier<Block>> validBlocks) {
+        //noinspection ConstantConditions
+        this(deferredRegister, name, () -> BlockEntityType.Builder.of(blockEntitySupplier, validBlocks.stream().map(Supplier::get).toArray(Block[]::new)).build(null));
+    }
+
+    public BlockEntityTypeRegistryObject(DeferredRegisterWrapper<BlockEntityType<?>> deferredRegister, String name, Supplier<BlockEntityType<T>> supplier) {
+        super(deferredRegister, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/BlockRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/BlockRegistryObject.java
@@ -1,0 +1,12 @@
+package net.silentchaos512.lib.registry.updated.registryobjects;
+
+import net.minecraft.world.level.block.Block;
+import net.silentchaos512.lib.registry.updated.deferredregisters.BlockDeferredRegister;
+
+import java.util.function.Supplier;
+
+public class BlockRegistryObject<T extends Block> extends UpdatedRegistryObjectWrapper<Block> {
+    public BlockRegistryObject(BlockDeferredRegister deferredRegister, String name, Supplier<T> supplier) {
+        super(deferredRegister, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/FluidRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/FluidRegistryObject.java
@@ -1,0 +1,12 @@
+package net.silentchaos512.lib.registry.updated.registryobjects;
+
+import net.minecraft.world.level.material.Fluid;
+import net.silentchaos512.lib.registry.updated.deferredregisters.DeferredRegisterWrapper;
+
+import java.util.function.Supplier;
+
+public class FluidRegistryObject<T extends Fluid> extends UpdatedRegistryObjectWrapper<Fluid> {
+    public FluidRegistryObject(DeferredRegisterWrapper<Fluid> deferredRegister, String name, Supplier<T> supplier) {
+        super(deferredRegister, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/FluidTypeRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/FluidTypeRegistryObject.java
@@ -1,0 +1,12 @@
+package net.silentchaos512.lib.registry.updated.registryobjects;
+
+import net.minecraftforge.fluids.FluidType;
+import net.silentchaos512.lib.registry.updated.deferredregisters.DeferredRegisterWrapper;
+
+import java.util.function.Supplier;
+
+public class FluidTypeRegistryObject<T extends FluidType> extends UpdatedRegistryObjectWrapper<FluidType> {
+    public FluidTypeRegistryObject(DeferredRegisterWrapper<FluidType> deferredRegister, String name, Supplier<T> supplier) {
+        super(deferredRegister, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/ItemRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/ItemRegistryObject.java
@@ -1,0 +1,12 @@
+package net.silentchaos512.lib.registry.updated.registryobjects;
+
+import net.minecraft.world.item.Item;
+import net.silentchaos512.lib.registry.updated.deferredregisters.DeferredRegisterWrapper;
+
+import java.util.function.Supplier;
+
+public class ItemRegistryObject<T extends Item> extends UpdatedRegistryObjectWrapper<Item> {
+    public ItemRegistryObject(DeferredRegisterWrapper<Item> deferredRegister, String name, Supplier<T> supplier) {
+        super(deferredRegister, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/RecipeSerializerRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/RecipeSerializerRegistryObject.java
@@ -1,0 +1,13 @@
+package net.silentchaos512.lib.registry.updated.registryobjects;
+
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraftforge.registries.DeferredRegister;
+
+import java.util.function.Supplier;
+
+public class RecipeSerializerRegistryObject<T extends Recipe<?>> extends UpdatedRegistryObjectWrapper<RecipeSerializer<?>> {
+    public RecipeSerializerRegistryObject(DeferredRegister<RecipeSerializer<?>> deferredRegister, String modid, String name, Supplier<RecipeSerializer<T>> supplier) {
+        super(deferredRegister, modid, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/RecipeTypeRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/RecipeTypeRegistryObject.java
@@ -1,0 +1,13 @@
+package net.silentchaos512.lib.registry.updated.registryobjects;
+
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.silentchaos512.lib.registry.updated.deferredregisters.DeferredRegisterWrapper;
+
+import java.util.function.Supplier;
+
+public class RecipeTypeRegistryObject<T extends Recipe<?>> extends UpdatedRegistryObjectWrapper<RecipeType<?>> {
+    public RecipeTypeRegistryObject(DeferredRegisterWrapper<RecipeType<?>> deferredRegister, String name, Supplier<RecipeType<T>> supplier) {
+        super(deferredRegister, name, supplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/UpdatedRegistryObjectWrapper.java
+++ b/src/main/java/net/silentchaos512/lib/registry/updated/registryobjects/UpdatedRegistryObjectWrapper.java
@@ -1,0 +1,29 @@
+package net.silentchaos512.lib.registry.updated.registryobjects;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.registries.DeferredRegister;
+import net.silentchaos512.lib.registry.RegistryObjectWrapper;
+import net.silentchaos512.lib.registry.updated.deferredregisters.DeferredRegisterWrapper;
+
+import java.util.function.Supplier;
+
+public abstract class UpdatedRegistryObjectWrapper<T> extends RegistryObjectWrapper<T> {
+    protected final ResourceLocation registryName;
+
+    public UpdatedRegistryObjectWrapper(DeferredRegisterWrapper<T> deferredRegister, String name, Supplier<? extends T> supplier) {
+        this(deferredRegister.instance, deferredRegister.modid, name, supplier);
+    }
+
+    public UpdatedRegistryObjectWrapper(DeferredRegister<T> deferredRegister, String modid, String name, Supplier<? extends T> supplier) {
+        super(deferredRegister.register(name, supplier));
+        this.registryName = new ResourceLocation(modid, name);
+    }
+
+    public ResourceLocation getRegistryName() {
+        return this.registryName;
+    }
+
+    public String getRegistryPath() {
+        return this.registryName.getPath();
+    }
+}


### PR DESCRIPTION
Deprecate (for removal) the BlockRegistryObject and ItemRegistryObject before moving entirely to the newly updated/added RegistryObject and DeferredRegistry wrappers.

Main purpose is re-adding the `ResourceLocation getRegistryName()` method from the removed `IForgeRegistryEntry` and to shorten the code