### PR TITLE
Adding deferred register wrappers with helper methods.

### DIFF
--- a/src/main/java/net/silentchaos512/lib/registry/BlockRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/BlockRegistryObject.java
@@ -1,10 +1,17 @@
 package net.silentchaos512.lib.registry;
 
 import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
 import net.silentchaos512.lib.block.IBlockProvider;
 
+import java.util.function.Supplier;
+
 public class BlockRegistryObject<T extends Block> extends RegistryObjectWrapper<T> implements IBlockProvider {
+    public BlockRegistryObject(DeferredRegister<Block> deferredRegister, String name, Supplier<T> blockSupplier) {
+        this(deferredRegister.register(name, blockSupplier));
+    }
+
     public BlockRegistryObject(RegistryObject<T> block) {
         super(block);
     }

--- a/src/main/java/net/silentchaos512/lib/registry/ItemRegistryObject.java
+++ b/src/main/java/net/silentchaos512/lib/registry/ItemRegistryObject.java
@@ -2,9 +2,17 @@ package net.silentchaos512.lib.registry;
 
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.RegistryObject;
 
+import java.util.function.Supplier;
+
 public class ItemRegistryObject<T extends Item> extends RegistryObjectWrapper<T> implements ItemLike {
+    public ItemRegistryObject(DeferredRegister<Item> deferredRegister, String name, Supplier<T> itemSupplier) {
+        this(deferredRegister.register(name, itemSupplier));
+    }
+
     public ItemRegistryObject(RegistryObject<T> item) {
         super(item);
     }

--- a/src/main/java/net/silentchaos512/lib/registry/deferred/BlockDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/deferred/BlockDeferredRegister.java
@@ -1,0 +1,53 @@
+package net.silentchaos512.lib.registry.deferred;
+
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.material.Material;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.RegisterEvent;
+import net.silentchaos512.lib.registry.BlockRegistryObject;
+
+import java.util.function.Supplier;
+
+public class BlockDeferredRegister extends DeferredRegisterWrapper<Block> {
+    public BlockDeferredRegister(String modid, IForgeRegistry<Block> registry) {
+        super(modid, registry);
+    }
+
+    /**
+     * Register all the registered blocks to item via {@link net.minecraftforge.registries.DeferredRegister<Item>}
+     *
+     * @see ItemDeferredRegister
+     */
+    public void registerBlockItems(ItemDeferredRegister itemDeferredRegister) {
+        super.getEntries().forEach(block -> itemDeferredRegister.register(block.getId().getPath(), () -> new BlockItem(block.get(), new Item.Properties().tab(itemDeferredRegister.defaultTab))));
+    }
+
+    /**
+     * Register all the registered blocks to item via {@link RegisterEvent}.
+     *
+     * @see <a href="https://docs.minecraftforge.net/en/1.19.x/concepts/registries/#registerevent">Register Event</a>
+     */
+    public void registerBlockItems(RegisterEvent.RegisterHelper<Item> registerHelper, CreativeModeTab defaultTab) {
+        super.getEntries().forEach(block -> registerHelper.register(block.getId(), new BlockItem(block.get(), new Item.Properties().tab(defaultTab))));
+    }
+
+    public <T extends Block> BlockRegistryObject<T> register(String name, Supplier<T> blockSupplier) {
+        return new BlockRegistryObject<>(this.deferredRegister, name, blockSupplier);
+    }
+
+    public BlockRegistryObject<Block> register(String name, Material material, int strength) {
+        return register(name, material, strength, strength);
+    }
+
+    public BlockRegistryObject<Block> register(String name, Material material, int hardness, int resistance) {
+        return register(name, () -> new Block(BlockBehaviour.Properties.of(material).strength(hardness, resistance)));
+    }
+
+    public BlockRegistryObject<Block> registerCopy(String name, Supplier<? extends Block> otherBlock) {
+        return register(name, () -> new Block(BlockBehaviour.Properties.copy(otherBlock.get())));
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/deferred/BlockEntityTypeDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/deferred/BlockEntityTypeDeferredRegister.java
@@ -1,0 +1,22 @@
+package net.silentchaos512.lib.registry.deferred;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public class BlockEntityTypeDeferredRegister extends DeferredRegisterWrapper<BlockEntityType<?>> {
+    public BlockEntityTypeDeferredRegister(String modid) {
+        super(modid, ForgeRegistries.BLOCK_ENTITY_TYPES);
+    }
+
+    @SafeVarargs
+    public final <T extends BlockEntity> RegistryObject<BlockEntityType<T>> register(String name, BlockEntityType.BlockEntitySupplier<T> blockEntitySupplier, Supplier<Block>... validBlocks) {
+        //noinspection ConstantConditions
+        return this.deferredRegister.register(name, () -> BlockEntityType.Builder.of(blockEntitySupplier, Stream.of(validBlocks).map(Supplier::get).toArray(Block[]::new)).build(null));
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/deferred/DeferredRegisterWrapper.java
+++ b/src/main/java/net/silentchaos512/lib/registry/deferred/DeferredRegisterWrapper.java
@@ -1,0 +1,24 @@
+package net.silentchaos512.lib.registry.deferred;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.IForgeRegistry;
+import net.minecraftforge.registries.RegistryObject;
+
+import java.util.stream.Stream;
+
+public class DeferredRegisterWrapper<T> {
+    protected final DeferredRegister<T> deferredRegister;
+
+    public DeferredRegisterWrapper(String modid, IForgeRegistry<T> registry) {
+        this.deferredRegister = DeferredRegister.create(registry, modid);
+    }
+
+    public void registerBus(IEventBus bus) {
+        this.deferredRegister.register(bus);
+    }
+
+    public Stream<RegistryObject<T>> getEntries() {
+        return this.deferredRegister.getEntries().stream();
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/registry/deferred/ItemDeferredRegister.java
+++ b/src/main/java/net/silentchaos512/lib/registry/deferred/ItemDeferredRegister.java
@@ -1,0 +1,25 @@
+package net.silentchaos512.lib.registry.deferred;
+
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.silentchaos512.lib.registry.ItemRegistryObject;
+
+import java.util.function.Supplier;
+
+public class ItemDeferredRegister extends DeferredRegisterWrapper<Item> {
+    public final CreativeModeTab defaultTab;
+
+    public ItemDeferredRegister(String modid, CreativeModeTab defaultTab) {
+        super(modid, ForgeRegistries.ITEMS);
+        this.defaultTab = defaultTab;
+    }
+
+    public ItemRegistryObject<Item> register(String name) {
+        return new ItemRegistryObject<>(super.deferredRegister, name, () -> new Item(new Item.Properties().tab(this.defaultTab)));
+    }
+
+    public <T extends Item> ItemRegistryObject<T> register(String name, Supplier<T> itemSupplier) {
+        return new ItemRegistryObject<>(super.deferredRegister, name, itemSupplier);
+    }
+}

--- a/src/main/java/net/silentchaos512/lib/util/NameUtils.java
+++ b/src/main/java/net/silentchaos512/lib/util/NameUtils.java
@@ -14,6 +14,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.IForgeRegistry;
 import net.silentchaos512.lib.block.IBlockProvider;
 
 import javax.annotation.Nullable;
@@ -40,6 +41,16 @@ public final class NameUtils {
         return name;
     }
 
+
+    /**
+     * Get registry name for a specific registered object
+     * @param registry - See {@link ForgeRegistries} for full list of all forge built-in registries
+     */
+    public static <T> ResourceLocation getNameFromRegistry(IForgeRegistry<T> registry, T value) {
+        ResourceLocation key = registry.getKey(value);
+        return checkNotNull(key);
+    }
+
     /**
      * Get a ResourceLocation with namespace "forge". Does not handle exceptions.
      *
@@ -59,7 +70,7 @@ public final class NameUtils {
      * @throws NullPointerException if registry name is null
      */
     public static ResourceLocation fromBlock(Block block) {
-        return checkNotNull(ForgeRegistries.BLOCKS.getKey(block));
+        return getNameFromRegistry(ForgeRegistries.BLOCKS, block);
     }
 
     /**
@@ -93,7 +104,7 @@ public final class NameUtils {
      * @throws NullPointerException if registry name is null
      */
     public static ResourceLocation fromEnchantment(Enchantment enchantment) {
-        return checkNotNull(ForgeRegistries.ENCHANTMENTS.getKey(enchantment));
+        return getNameFromRegistry(ForgeRegistries.ENCHANTMENTS, enchantment);
     }
 
     /**
@@ -115,7 +126,7 @@ public final class NameUtils {
      * @throws NullPointerException if registry name is null
      */
     public static ResourceLocation fromEntityType(EntityType<?> type) {
-        return checkNotNull(ForgeRegistries.ENTITY_TYPES.getKey(type));
+        return getNameFromRegistry(ForgeRegistries.ENTITY_TYPES, type);
     }
 
     /**
@@ -126,7 +137,7 @@ public final class NameUtils {
      * @throws NullPointerException if registry name is null
      */
     public static ResourceLocation fromFluid(Fluid fluid) {
-        return checkNotNull(ForgeRegistries.FLUIDS.getKey(fluid));
+        return getNameFromRegistry(ForgeRegistries.FLUIDS, fluid);
     }
 
     /**
@@ -149,7 +160,7 @@ public final class NameUtils {
      */
     public static ResourceLocation fromItem(ItemLike item) {
         Preconditions.checkNotNull(item.asItem(), "asItem() is null, has object not been fully constructed?");
-        return checkNotNull(ForgeRegistries.ITEMS.getKey(item.asItem()));
+        return getNameFromRegistry(ForgeRegistries.ITEMS, item.asItem());
     }
 
     /**
@@ -171,6 +182,6 @@ public final class NameUtils {
      * @throws NullPointerException if registry name is null
      */
     public static ResourceLocation fromRecipeSerializer(RecipeSerializer<? extends Recipe<?>> serializer) {
-        return checkNotNull(ForgeRegistries.RECIPE_SERIALIZERS.getKey(serializer));
+        return getNameFromRegistry(ForgeRegistries.RECIPE_SERIALIZERS, serializer);
     }
 }


### PR DESCRIPTION
Added a few `DeferredRegisterWrapper`s for `Block`, `Item`, and `BlockEntityType<?>` as a helper class and also a placeholder for `DeferredRegister`.
Main purpose, include all the helper methods (kinda) so developers don't need to add more helper methods to their class(es)